### PR TITLE
Change Callback args order

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,8 +17,8 @@ class App extends Component {
             placeholder='Enter here...'
             value="Test Value"
             className="be-rtf-editor"
-            onBlur ={(e, value, rtfInput) => console.log(e, value, rtfInput)}
-            onFocus={(e, value, rtfInput) => console.log(e, value, rtfInput)}
+            onBlur ={(value, e, rtfInput) => console.log(value, e, rtfInput)}
+            onFocus={(value, e, rtfInput) => console.log(value, e, rtfInput)}
             onChange={(value) => console.log(value)}
         />
           <hr />

--- a/src/Components/RTFInput/RTFInput.jsx
+++ b/src/Components/RTFInput/RTFInput.jsx
@@ -57,7 +57,7 @@ export default class RTFInput extends React.Component {
 
         this._onWindowClickHandler = this.onWindowClick.bind(this);
     }
-
+    
     hideRTFDropdown() {
         this.setState({ showDropdown: false });
     }
@@ -190,8 +190,8 @@ export default class RTFInput extends React.Component {
                         placeholder={this.props.placeholder}
                         value={this.state.inputValue}
                         onChange={(e) => this.onTextInputChange(e)}
-                        onFocus={(e) => (this.props.onFocus || (() => { }))(e, html, this)}
-                        onBlur={(e) => (this.props.onBlur || (() => { }))(e, html, this)}
+                        onFocus={(e) => (this.props.onFocus || (() => { }))(html, e, this)}
+                        onBlur={(e) => (this.props.onBlur || (() => { }))(html, e, this)}
                         title={htmlToText.fromString(html, { preserveNewlines: true })}
                     />
                     <span
@@ -206,8 +206,8 @@ export default class RTFInput extends React.Component {
                         toolbar={RTFInput.toolbarDef}
                         editorState={editorContents[0]}
                         onEditorStateChange={(content) => this.onEditorStateChange(content)}
-                        onFocus={(e) => (this.props.onFocus || (() => { }))(e, html, this)}
-                        onBlur={(e) => (this.props.onBlur || (() => { }))(e, html, this)}
+                        onFocus={(e) => (this.props.onFocus || (() => { }))(html, e, this)}
+                        onBlur={(e) => (this.props.onBlur || (() => { }))(html, e, this)}
                         textAlignment={isRtl ? 'right' : 'left'}
                     />
                 </div>


### PR DESCRIPTION
i've changed the order of the callbacks arguments.
the `html` is the first arg now.

- most of the time this is value one would use.

- moreover, we also use the same api around line 128 so it's more consistent: 

### ~line 128
```
if (editorContent) {
            this.setState({ inputValue: text, editorContents: [editorContent] });
            (this.props.onChange || (() => { }))(html);
        } else {
            this.setState({ inputValue: text });
        }
```


@lior2710 
